### PR TITLE
개발자용 JWT 마스터키 도입

### DIFF
--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -16,6 +16,7 @@ services:
       - MONGO_PORT=27017
       - MONGO_DB=jyp
       - JWT_SECRET_KEY=yoonminzzang
+      - JWT_MASTER_KEY=master
     links:
       - "mongo:mongo"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
       - MONGO_PORT=27017
       - MONGO_DB=jyp
       - JWT_SECRET_KEY=yoonminzzang
+      - JWT_MASTER_KEY=master
     links:
       - "mongo:mongo"
     depends_on:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UserModule } from './user/user.module';
@@ -6,6 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { JourneyModule } from './journey/journey.module';
+import { AuthMiddleware } from './auth/security/auth.middleware';
 
 const MONGO_USER = process.env.MONGO_USER;
 const MONGO_PASSWORD = process.env.MONGO_PASSWORD;
@@ -27,4 +28,8 @@ const MONGO_DB = process.env.MONGO_DB;
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(AuthMiddleware).forRoutes('*');
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -49,6 +49,7 @@ import { Environment } from '../common/environment';
     UserRepository,
     AuthKakaoService,
   ],
+  exports: [JwtModule],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/security/auth.middleware.ts
+++ b/src/auth/security/auth.middleware.ts
@@ -1,0 +1,28 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { NextFunction } from 'express';
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  private readonly masterKey = process.env.JWT_MASTER_KEY;
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const inputMasterKey = req.headers['jyp-jwt-master-key'];
+    if (this.masterKey && inputMasterKey != this.masterKey) {
+      next();
+      return;
+    }
+    const overrideId = req.headers['jyp-override-id'];
+    if (!overrideId) {
+      next();
+      return;
+    }
+    const payload = { id: overrideId };
+    const token = this.jwtService.sign(payload);
+    const authHeader = `Bearer ${token}`;
+    req.headers['authorization'] = authHeader;
+    next();
+  }
+}


### PR DESCRIPTION
# Updates
* 미들웨어를 이용해 개발자용 JWT 마스터키 도입: 특정 헤더를 사용해 JWT guard 바이패스 가능
# Checklist
- [ ] 머지 대상 확인
