### PR TITLE
태그가 없는 저니 GET api 호출 시 에러 버그 수정

### DIFF
--- a/src/journey/dtos/journey.dto.ts
+++ b/src/journey/dtos/journey.dto.ts
@@ -155,7 +155,7 @@ export class TagResponseDTO implements TagResponse {
           left.set(key, leftVal.concat(rightVal));
         }
         return left;
-      });
+      }, new Map());
     const aggregated = [];
     for (const entry of grouped.entries()) {
       const [key, users] = entry;

--- a/src/journey/journey.service.spec.ts
+++ b/src/journey/journey.service.spec.ts
@@ -558,6 +558,53 @@ describe('JourneyService', () => {
       expect(result).toEqual(expectedResult);
     });
 
+    it('저니에 태그, 픽미, 피키가 없는 케이스.', async () => {
+      // given
+      const lightJourney = new Journey(
+        JOURNEY_NAME,
+        START_DATE,
+        END_DATE,
+        THEME_PATH,
+        [USER],
+        [],
+        [],
+        [],
+      ) as JourneyDocument;
+      lightJourney._id = new mongoose.Types.ObjectId(JOURNEY_ID);
+      journeyRepository.get = jest.fn().mockResolvedValue(lightJourney);
+
+      // when
+      const result = await journeyService.getJourney(JOURNEY_ID);
+
+      // then
+      expect(journeyRepository.get).toBeCalledTimes(1);
+      expect(journeyRepository.get).toBeCalledWith(JOURNEY_ID, {
+        populateUsers: true,
+        populateTags: true,
+        populatePikmis: true,
+        populatePikis: true,
+      });
+      const expectedResult = new JourneyResponseDTO(
+        JOURNEY_ID,
+        JOURNEY_NAME,
+        START_DATE,
+        END_DATE,
+        THEME_PATH,
+        [
+          new UserResponseDTO(
+            USER._id,
+            USER.name,
+            USER.img,
+            PERSONALITY[USER.psn],
+          ),
+        ],
+        [],
+        [],
+        [],
+      );
+      expect(result).toEqual(expectedResult);
+    });
+
     it('해당하는 저니가 없으면 NotFoundException을 throw한다.', async () => {
       // given
       journeyRepository.get = jest.fn().mockResolvedValue(null);


### PR DESCRIPTION
# Updates
* 태그가 없는 저니 GET api 호출 시 에러 버그 수정
# Checklist
- [ ] 머지 대상 확인
